### PR TITLE
Added missing bcmath php extension

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN apt-get update \
         pdo_mysql \
         zip \
         opcache \
+        bcmath \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install gd \
     && pecl install xdebug \


### PR DESCRIPTION
For some projects (myworkup) bcmath extension is needed and it's not provided by the base php7 docker image.